### PR TITLE
Concurrency control (using global mutex)

### DIFF
--- a/daos/mainDao.go
+++ b/daos/mainDao.go
@@ -80,7 +80,7 @@ func InsertInShortenedUrl(urlModel model.UrlModel) {
 	insertResult, err := collection.InsertOne(context.Background(), urlModel)
 
 	if err != nil {
-		log.Fatal("Error while writing to shortened_url collection", err)
+		log.Fatal("Error while writing to shortened_url collection ", err)
 	}
 
 	log.Println("InsertedId", insertResult.InsertedID)

--- a/services/mainService.go
+++ b/services/mainService.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -24,6 +25,7 @@ var err error
 
 // EXPIRY_TIME - TTL for an item int cache
 var EXPIRY_TIME int
+var mutex sync.Mutex
 
 func init() {
 	dir, _ := os.Getwd()
@@ -43,6 +45,8 @@ func init() {
 // CreateShortenedUrl - This service shortens a give url.
 func CreateShortenedUrl(inputUrl string) string {
 
+	mutex.Lock()
+	// FIXME: mutex wont guarantee consistency.
 	counterVal := dao.GetCounterValue()
 	newUrl := GenerateShortenedUrl(counterVal)
 	inputModel := model.UrlModel{UniqueId: counterVal, Url: inputUrl, CreatedAt: time.Now()}
@@ -68,6 +72,8 @@ func CreateShortenedUrl(inputUrl string) string {
 	// You could have mutexes as well, but mutex would have guaranteed consistency.
 	dao.InsertInShortenedUrl(inputModel)
 	dao.UpdateCounter()
+	mutex.Unlock()
+
 	return newUrl
 }
 


### PR DESCRIPTION
Use a Mutex (global one), over request level for concurrency control. 